### PR TITLE
📄 Add VLMT (2025) paper to Multi-modal LLMs for NLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,10 @@
    
    *Chancharik Mitra, Brandon Huang, Trevor Darrell, Roei Herzig.* [[abs](https://arxiv.org/abs/2311.17076)], 2023.4
 
+10. **VLMT: Vision-Language Multimodal Transformer for Multimodal Multi-hop Question Answering**  
+   
+   *Qi Zhi Lim, Chin Poo Lee, Kian Ming Lim, Kalaiarasi Sonai Muthu Anbananthen.* [[abs](https://arxiv.org/abs/2504.08269)], 2025.4
+
 #### Tool-usage in LLMs for NLP
 
 1. **ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs**

--- a/README.md
+++ b/README.md
@@ -681,6 +681,9 @@
    
    *Bin Lei, pei-Hung Lin, Chunhua Liao, Caiwen Ding.* [[abs](https://arxiv.org/abs/2308.08614)], 2023.8
 
+7. **Demystifying Chains, Trees, and Graphs of Thoughts**
+
+   *Maciej Besta, Florim Memedi, Zhenyu Zhang, Robert Gerstenberger, Nils Blach, Piotr Nyczyk, Marcin Copik, Grzegorz Kwaśniewski, Jürgen Müller, Lukas Gianinazzi, Ales Kubicek, Hubert Niewiadomski, Aidan O'Mahony, Onur Mutlu, Torsten Hoefler.* [[abs](https://arxiv.org/abs/2401.14295)], 2025.1
 
 #### Hallucination in LLMs for NLP
 


### PR DESCRIPTION
This pull request adds the following 2025 paper to the "Multi-modal LLMs for NLP" section:

- title: VLMT: Vision-Language Multimodal Transformer for Multimodal Multi-hop Question Answering  
- paper: arXiv 2504.08269  
- author: Qi Zhi Lim, Chin Poo Lee, Kian Ming Lim, Kalaiarasi Sonai Muthu Anbananthen  
- key-point: A unified architecture for multimodal multi-hop QA with direct visual-token injection; achieves SOTA on MultimodalQA.

Let me know if edits are needed. Thanks!